### PR TITLE
Changes to conform to CY2015/CY2016 on Linux (gcc 4.8.2 with fix, glibc 2.12).

### DIFF
--- a/src/O_Common.h
+++ b/src/O_Common.h
@@ -40,6 +40,7 @@ Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.p
 #include <iomanip>
 #include <string>
 #include <vector>
+#include <cstring>
 
 #ifdef _WIN32
 	#include <glm\glm.hpp>

--- a/src/kettle/KettleBaker.h
+++ b/src/kettle/KettleBaker.h
@@ -21,6 +21,8 @@
 #include <exception>
 #include <stdexcept>
 #include <string>
+#include <cstring>
+#include <cstdio>
 
 #include "arnold_utils.h"
 


### PR DESCRIPTION
Hi Marc-Antoine,

Here are the fixes I told you about to be able to compile on a machine conforming to the CY2015/CY2016 requirements of the VFX Platform : http://www.vfxplatform.com

Can you please pull ? Thanks.

Vincent
